### PR TITLE
Generic Base Field

### DIFF
--- a/src-tauri/src/evaluator.rs
+++ b/src-tauri/src/evaluator.rs
@@ -1,22 +1,21 @@
-use crate::types::{Context, CResult, LatexExpr, Expr::{self, *}};
-use crate::unit_value::UnitVal;
+use crate::types::{BaseField, CResult, Context, Expr::{self, *}, LatexExpr};
 use crate::error::Error;
 
 use itertools::Itertools;
 
 
 #[derive(Debug, Clone)]
-pub struct Evaluator {
-    pub context: Context,
+pub struct Evaluator<T> where for<'a> T: BaseField<'a> {
+    pub context: Context<T>,
     pub defining: Option<String>,
 }
 
-impl Evaluator {
+impl<T> Evaluator<T> where for<'a> T: BaseField<'a> {
     pub fn new() -> Self {
         Evaluator { context: Context::new(), defining: None }
     }
 
-    pub fn eval_expr_mut_context(&mut self, expr: &Expr) -> CResult<Option<UnitVal>> {
+    pub fn eval_expr_mut_context(&mut self, expr: &Expr<T>) -> CResult<Option<T>> {
         match expr {
             EDefVar(var, expr) => {
                 if self.defining.is_some() {
@@ -45,7 +44,7 @@ impl Evaluator {
         }
     }
  
-    pub fn eval_expr(&self, expr: &Expr) -> CResult<UnitVal> {
+    pub fn eval_expr(&self, expr: &Expr<T>) -> CResult<T> {
     
         match expr {
             ENum(num) => Ok(num.clone()),
@@ -84,20 +83,20 @@ impl Evaluator {
         }
     }
 
-    fn apply_default_function(&self, name: &str, inputs: &Vec<Expr>) -> CResult<UnitVal> {
+    fn apply_default_function(&self, name: &str, inputs: &Vec<Expr<T>>) -> CResult<T> {
         if inputs.len() != 1 {
             return Err(Error::EvalError(format!("Default functions only accept one argument, received {} for {name}", inputs.len())));
         }
-        let input = self.eval_expr(inputs.get(0).unwrap())?.as_scalar()?;
+        let input = self.eval_expr(inputs.get(0).unwrap())?;
         match name {
-            "sin" => Ok(UnitVal::scalar(input.sin())),
-            "cos" => Ok(UnitVal::scalar(input.cos())),
-            "tan" => Ok(UnitVal::scalar(input.tan())),
+            "sin" => input.sin(),
+            "cos" => input.cos(),
+            "tan" => input.tan(),
             _ => Err(Error::EvalError(format!("Function '{name}' not defined")))
         }
     }
 
-    fn eval_latex(&self, expr: &LatexExpr) -> CResult<UnitVal> {
+    fn eval_latex(&self, expr: &LatexExpr<T>) -> CResult<T> {
         match expr.name.as_str() {
             "frac" => {
                 if expr.params.len() != 2 {
@@ -134,7 +133,7 @@ impl Evaluator {
         }
     }
 
-    fn evaluate_repetition(&self, expr: &LatexExpr, op: impl Fn(f32, f32) -> f32, identity: f32) -> Result<UnitVal, Error> {
+    fn evaluate_repetition(&self, expr: &LatexExpr<T>, op: impl Fn(f32, f32) -> f32, identity: f32) -> Result<T, Error> {
         if expr.params.len() != 1 || expr.subscript.is_none() || expr.superscript.is_none() {
             return Err(Error::EvalError(format!("Summation expects a parameter, a subscript, and a superscript, received {:?}", expr)));
         }
@@ -142,7 +141,7 @@ impl Evaluator {
         let superscript = expr.superscript.as_ref().unwrap();
         let subscript = expr.subscript.as_ref().unwrap();
         let ub = self.eval_expr(&superscript)?;
-    
+
         let mut sum_eval = self.clone();
         let lb_var = match *subscript.clone() {
             EDefVar(name, _) => Some(name),
@@ -156,15 +155,15 @@ impl Evaluator {
         }
         let up = ub.as_scalar()? as i32 + 1;
         let ub = lb.as_scalar()? as i32;
-    
+
         let mut sum = identity;
         for i in ub..up {
             if lb_var.is_some() {
-                sum_eval.context.vars.insert(lb_var.clone().unwrap(), UnitVal::scalar(i as f32));
+                sum_eval.context.vars.insert(lb_var.clone().unwrap(), (i as f32).into());
             }
             sum = op(sum, sum_eval.eval_expr(&param)?.as_scalar()?);
         }
-        Ok(UnitVal::scalar(sum))
+        Ok(sum.into())
     }
 }
 
@@ -172,17 +171,19 @@ impl Evaluator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::unit_value::UnitVal;
 
-    fn evaluate(expr: Expr) -> UnitVal {
+
+    fn evaluate(expr: Expr<UnitVal>) -> UnitVal {
         let mut eval = Evaluator::new();
         eval.eval_expr_mut_context(&expr).unwrap().unwrap()
     }
 
-    fn num(x: f32) -> Expr {
+    fn num(x: f32) -> Expr<UnitVal> {
         ENum(UnitVal::scalar(x))
     }
 
-    fn boxed_num(x: f32) -> Box<Expr> {
+    fn boxed_num(x: f32) -> Box<Expr<UnitVal>> {
         Box::new(num(x))
     }
 

--- a/src-tauri/src/evaluator.rs
+++ b/src-tauri/src/evaluator.rs
@@ -133,7 +133,7 @@ impl<T> Evaluator<T> where for<'a> T: BaseField<'a> {
         }
     }
 
-    fn evaluate_repetition(&self, expr: &LatexExpr<T>, op: impl Fn(f32, f32) -> f32, identity: f32) -> Result<T, Error> {
+    fn evaluate_repetition(&self, expr: &LatexExpr<T>, op: impl Fn(f64, f64) -> f64, identity: f64) -> Result<T, Error> {
         if expr.params.len() != 1 || expr.subscript.is_none() || expr.superscript.is_none() {
             return Err(Error::EvalError(format!("Summation expects a parameter, a subscript, and a superscript, received {:?}", expr)));
         }
@@ -159,7 +159,7 @@ impl<T> Evaluator<T> where for<'a> T: BaseField<'a> {
         let mut sum = identity;
         for i in ub..up {
             if lb_var.is_some() {
-                sum_eval.context.vars.insert(lb_var.clone().unwrap(), (i as f32).into());
+                sum_eval.context.vars.insert(lb_var.clone().unwrap(), (i as f64).into());
             }
             sum = op(sum, sum_eval.eval_expr(&param)?.as_scalar()?);
         }
@@ -179,11 +179,11 @@ mod tests {
         eval.eval_expr_mut_context(&expr).unwrap().unwrap()
     }
 
-    fn num(x: f32) -> Expr<UnitVal> {
+    fn num(x: f64) -> Expr<UnitVal> {
         ENum(UnitVal::scalar(x))
     }
 
-    fn boxed_num(x: f32) -> Box<Expr<UnitVal>> {
+    fn boxed_num(x: f64) -> Box<Expr<UnitVal>> {
         Box::new(num(x))
     }
 

--- a/src-tauri/src/evaluator.rs
+++ b/src-tauri/src/evaluator.rs
@@ -116,7 +116,7 @@ impl<T> Evaluator<T> where for<'a> T: BaseField<'a> {
                     return Err(Error::EvalError("Square root does not support subscripts or superscripts".to_string()));
                 }
                 let val = expr.params.get(0).unwrap();
-                Ok(self.eval_expr(val)?.root(2)?)
+                Ok(self.eval_expr(val)?.root(2.0.into())?)
             },
             "sum" => {
                 self.evaluate_repetition(expr, |a, b| a + b, 0.0)

--- a/src-tauri/src/fields.rs
+++ b/src-tauri/src/fields.rs
@@ -1,0 +1,205 @@
+use crate::error;
+use crate::types::{CResult, BaseField};
+use std::ops::{Add, Sub, Mul, Div};
+use std::convert::{TryFrom, From};
+use serde::Serialize;
+use num_complex::Complex as NumComplex;
+
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Float {
+    value: f64,
+}
+
+
+impl<'a> BaseField<'a> for Float {
+    fn as_scalar(&self) -> CResult<f64> {
+        Ok(self.value)
+    }
+
+    fn powf(&self, exp: Self) -> CResult<Self> {
+        Ok(Float { value: self.value.powf(exp.value) })
+    }
+
+    fn root(&self, n: Self) -> CResult<Self> {
+        Ok(Float { value: self.value.powf(1.0 / n.value) })
+    }
+
+    fn fract(&self) -> CResult<f64> {
+        Ok(self.value.fract())
+    }
+
+    fn sin(&self) -> CResult<Self> {
+        Ok(Float { value: self.value.sin() })
+    }
+
+    fn cos(&self) -> CResult<Self> {
+        Ok(Float { value: self.value.cos() })
+    }
+
+    fn tan(&self) -> CResult<Self> {
+        Ok(Float { value: self.value.tan() })
+    }
+}
+
+impl TryFrom<&str> for Float {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let value = s.parse::<f64>()?;
+        Ok(Float { value })
+    }
+}
+
+impl From<f64> for Float {
+    fn from(value: f64) -> Self {
+        Float { value }
+    }
+}
+
+impl Add for Float {
+    type Output = CResult<Self>;
+
+    fn add(self, other: Self) -> CResult<Self> {
+        Ok(Float { value: self.value + other.value })
+    }
+}
+
+impl Sub for Float {
+    type Output = CResult<Self>;
+
+    fn sub(self, other: Self) -> CResult<Self> {
+        Ok(Float { value: self.value - other.value })
+    }
+}
+
+impl Mul for Float {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Float { value: self.value * other.value }
+    }
+}
+
+impl Div for Float {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        Float { value: self.value / other.value }
+    }
+}
+
+impl std::fmt::Display for Float {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl Serialize for Float {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+        serializer.serialize_f64(self.value)
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Complex {
+    value: NumComplex<f64>,
+}
+
+impl<'a> BaseField<'a> for Complex {
+    fn as_scalar(&self) -> CResult<f64> {
+        if self.value.im == 0.0 {
+            Ok(self.value.re)
+        } else {
+            Err(error::Error::EvalError("Complex number is not a scalar".to_string()))
+        }
+    }
+
+    fn powf(&self, exp: Self) -> CResult<Self> {
+        Ok(Complex { value: self.value.powc(exp.value) })
+    }
+
+    fn root(&self, n: Self) -> CResult<Self> {
+        Ok(Complex { value: self.value.powc(1.0 / n.value) })
+    }
+
+    fn fract(&self) -> CResult<f64> {
+        let val = self.as_scalar()?;
+        Ok(val.fract())
+    }
+
+    fn sin(&self) -> CResult<Self> {
+        Ok(Complex { value: self.value.sin() })
+    }
+
+    fn cos(&self) -> CResult<Self> {
+        Ok(Complex { value: self.value.cos() })
+    }
+
+    fn tan(&self) -> CResult<Self> {
+        Ok(Complex { value: self.value.tan() })
+    }
+}
+
+impl std::fmt::Display for Complex {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl TryFrom<&str> for Complex {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        if s == "i" {
+            Ok(Complex { value: NumComplex::new(0.0, 1.0) })
+        } else {
+            Err(Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid complex number")))
+        }
+    }
+}
+
+impl From<f64> for Complex {
+    fn from(value: f64) -> Self {
+        Complex { value: NumComplex::new(value, 0.0) }
+    }
+}
+
+impl Add for Complex {
+    type Output = CResult<Self>;
+
+    fn add(self, other: Self) -> CResult<Self> {
+        Ok(Complex { value: self.value + other.value })
+    }
+}
+
+impl Sub for Complex {
+    type Output = CResult<Self>;
+
+    fn sub(self, other: Self) -> CResult<Self> {
+        Ok(Complex { value: self.value - other.value })
+    }
+}
+
+impl Mul for Complex {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Complex { value: self.value * other.value }
+    }
+}
+
+impl Div for Complex {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        Complex { value: self.value / other.value }
+    }
+}
+
+impl Serialize for Complex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+        serializer.serialize_str(&self.value.to_string())
+    }
+}

--- a/src-tauri/src/parser.rs
+++ b/src-tauri/src/parser.rs
@@ -1,7 +1,6 @@
-use crate::types::{CResult, *, Expr::*};
+use crate::types::{*, Expr::*};
 use crate::error::{Error, ParseError};
 use crate::parsing_helpers::*;
-use crate::unit_value::UnitVal;
 
 use nom::branch::alt;
 use nom::character::complete::{alpha1, char, digit1, space0};
@@ -15,7 +14,7 @@ use std::str::FromStr;
 
 
 
-pub(crate) fn parse(input: Span) -> CResult<Expr> {
+pub(crate) fn parse<T>(input: Span) -> CResult<Expr<T>> where for<'a> T: BaseField<'a> + 'a {
     let result = parse_math_expr_or_def(input);
     match result {
         Ok((input, expr)) => {
@@ -31,12 +30,12 @@ pub(crate) fn parse(input: Span) -> CResult<Expr> {
     }
 }
 
-fn parse_math_expr_or_def(input: Span) -> ParseResult {
+fn parse_math_expr_or_def<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     let (input, expr) = alt((parse_def, parse_math_expr))(input)?;
     Ok((input, expr))
 }
 
-fn parse_def(input: Span) -> ParseResult {
+fn parse_def<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     let (rhs, lhs) = take_until("=")(input)?;
     if lhs.contains('{') {
         return Err(nom::Err::Error(
@@ -48,7 +47,7 @@ fn parse_def(input: Span) -> ParseResult {
     let (rhs, _) = space0(rhs)?;
     let (rhs, expr) = prepend_cut(parse_math_expr, "In RHS of definition")(rhs)?;
     if lhs.contains('(') {
-        let (_, params) = mcut(parse_call_params,"Invalid function parameters")(lhs)?;
+        let (_, params) = mcut(parse_call_params::<T>,"Invalid function parameters")(lhs)?;
         // Assert each params is just a Var and get the string that makes it
         let mut param_strs = vec![String::from(""); params.len()];
         for (i, param) in params.iter().enumerate() {
@@ -63,7 +62,7 @@ fn parse_def(input: Span) -> ParseResult {
     }
 }
 
-fn parse_math_expr(input: Span) -> ParseResult {
+fn parse_math_expr<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     // println!("expr -> term: {:?}", input.fragment());
     let (input, num1) = parse_term(input)?;
     let term_splitters = alt((tag("+"), tag("-"))); 
@@ -73,7 +72,7 @@ fn parse_math_expr(input: Span) -> ParseResult {
     Ok((input, map_ops(num1, exprs)))
 }
 
-fn parse_term(input: Span) -> ParseResult {
+fn parse_term<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     // println!("term -> factor: {:?}", input.fragment());
     let (input, num1) = parse_term_no_fractions(input)?;
     let term_splitters = alt((tag("/"), tag("*"), tag("\\cdot"))); 
@@ -83,7 +82,7 @@ fn parse_term(input: Span) -> ParseResult {
     Ok((input, map_ops(num1, exprs)))
 }
 
-fn parse_term_no_fractions(input: Span) -> ParseResult {
+fn parse_term_no_fractions<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     // println!("factor -> insides: {:?}", input.fragment());
     let (input, base) = parse_component(input)?;
     // println!("factor -> factor: {:?}", input.fragment());
@@ -92,27 +91,27 @@ fn parse_term_no_fractions(input: Span) -> ParseResult {
     Ok((input, map_ops(base, exprs)))
 }
 
-fn parse_component(input: Span) -> ParseResult {
+fn parse_component<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     // println!("insides -> alt: {:?}", input.fragment());
     let (input, _) = trim(space0)(input)?;
     alt((parse_parens, parse_implicit_multiply, parse_func_call, parse_latex, parse_number, parse_var_use))(input)
 }
 
-fn parse_implicit_multiply(input: Span) -> ParseResult {
+fn parse_implicit_multiply<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     let (input, (num, var)) = 
     pair(parse_number, parse_term_no_fractions)(input)?;
     // println!("found implicit multiply");
     Ok((input, EMul(Box::new(num), Box::new(var))))
 }
 
-fn parse_func_call(input: Span) -> ParseResult {
+fn parse_func_call<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     let (input, name) = start_alpha(input)?;
     let (input, params) = parse_call_params(input)?;
     // println!("found func call");
     Ok((input, EFunc(name.to_string(), params)))
 }
 
-fn parse_call_params(input: Span) -> ParseResultVec {
+fn parse_call_params<T>(input: Span) -> ParseResultVec<T> where for<'a> T: BaseField<'a> + 'a {
     delimited(
         alt((tag("("), tag("\\left("))), 
         separated_list0(char(','), parse_math_expr), 
@@ -120,7 +119,7 @@ fn parse_call_params(input: Span) -> ParseResultVec {
     )(input)
 }
 
-fn parse_latex(input: Span) -> ParseResult {
+fn parse_latex<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     // println!("testing for latex: {:?}", input.fragment());
     let (rest, (_, func_name, script_params)) = tuple((
         char('\\'), alpha1, 
@@ -162,8 +161,10 @@ fn parse_latex(input: Span) -> ParseResult {
 }
 
 
-fn parse_latex_param<'a, F>(f: F) -> impl FnMut(Span<'a>) -> ParseResult<'a>
-    where F: Fn(Span<'a>) -> ParseResult<'a> + Copy
+fn parse_latex_param<F, T>(f: F) -> impl FnMut(Span) -> ParseResult<T>
+    where
+        for<'a> T: BaseField<'a> + 'a,
+        F: Fn(Span) -> ParseResult<T> + Copy,
 {
     move |input: Span| {
         let param = delimited(tag("{"), f, tag("}"))(input);
@@ -181,55 +182,52 @@ fn parse_latex_param<'a, F>(f: F) -> impl FnMut(Span<'a>) -> ParseResult<'a>
     }
 }
 
-fn parse_number(input: Span) -> ParseResult {
+fn parse_number<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     alt((
         parse_decimal,
         map(trim(digit1), parse_enum),
     ))(input)
 }
 
-fn parse_decimal(input: Span) -> ParseResult {
+fn parse_decimal<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     let (rest, num) = tuple((digit1, char('.'), digit1))(input)?;
     let num = format!("{}.{}", num.0, num.2);
     Ok((rest, into_enum(&num)))
 }
 
-fn parse_enum(parsed_num: Span) -> Expr {
+fn parse_enum<T>(parsed_num: Span) -> Expr<T> where for<'a> T: BaseField<'a> + 'a {
     into_enum(parsed_num.fragment())
 }
 
-fn into_enum(parsed_num: &str) -> Expr {
+fn into_enum<T>(parsed_num: &str) -> Expr<T> where for<'a> T: BaseField<'a> + 'a {
     let num = f32::from_str(parsed_num).unwrap();
-    ENum(UnitVal::scalar(num))
+    ENum(num.into())
 }
 
-fn parse_var_use(input: Span) -> ParseResult {
+fn parse_var_use<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     map(trim(start_alpha), parse_evar)(input)
 }
 
-fn parse_evar(input: Span) -> Expr {
+fn parse_evar<T>(input: Span) -> Expr<T> where for<'a> T: BaseField<'a> + 'a {
     match_const(input)
         .or_else(|_| match_unit(input))
-        .or_else(|_| Ok::<Expr, &str>(EVar(input.fragment().to_string()))).unwrap()
+        .or_else(|_| Ok::<Expr<T>, Box<dyn std::error::Error>>(EVar(input.fragment().to_string()))).unwrap()
 }
 
-fn match_unit(input: Span) -> Result<Expr, &str> {
-    if UnitVal::is_valid_unit(input.fragment()) {
-        Ok(ENum(UnitVal::new_identity(input.fragment())))
-    } else {
-        Err("Invalid unit")
-    }
+fn match_unit<T>(input: Span) -> Result<Expr<T>, Box<dyn std::error::Error>> where for<'a> T: BaseField<'a> + 'a {
+    let unit_val = (*input.fragment()).try_into()?;
+    Ok(ENum(unit_val))
 }
 
-fn match_const(input: Span) -> Result<Expr, &str> {
+fn match_const<T>(input: Span) -> Result<Expr<T>, Box<dyn std::error::Error>> where for<'a> T: BaseField<'a> + 'a {
     match *input.fragment() {
-        "e" => Ok(ENum(UnitVal::scalar(std::f32::consts::E))),
-        "pi" => Ok(ENum(UnitVal::scalar(std::f32::consts::PI))),
-        _ => Err("Unknown constant"),
+        "e" => Ok(ENum(std::f32::consts::E.into())),
+        "pi" => Ok(ENum(std::f32::consts::PI.into())),
+        _ => Err(Box::new(ParseError::new("Unknown constant", input))),
     }
 }
 
-fn parse_parens(input: Span) -> ParseResult {
+fn parse_parens<T>(input: Span) -> ParseResult<T> where for<'a> T: BaseField<'a> + 'a {
     trim(delimited(
         alt((tag("("), tag("\\left("))), 
         parse_math_expr,
@@ -237,11 +235,11 @@ fn parse_parens(input: Span) -> ParseResult {
     ))(input)
 }
 
-fn map_ops(expr: Expr, rem: Vec<(Span, Expr)>) -> Expr {
-    rem.into_iter().fold(expr, |acc, val| parse_op(val, acc))
+fn map_ops<T>(expr: Expr<T>, rem: Vec<(Span, Expr<T>)>) -> Expr<T> where for<'a> T: BaseField<'a> + 'a {
+    rem.into_iter().fold(expr, |acc, val: (Span, Expr<T>)| parse_op(val, acc))
 }
 
-fn parse_op(tup: (Span, Expr), expr1: Expr) -> Expr {
+fn parse_op<T>(tup: (Span, Expr<T>), expr1: Expr<T>) -> Expr<T> where for<'a> T: BaseField<'a> + 'a {
     let (op, expr2) = tup;
     match *op.fragment() {
         "+" => EAdd(Box::new(expr1), Box::new(expr2)),
@@ -257,32 +255,33 @@ fn parse_op(tup: (Span, Expr), expr1: Expr) -> Expr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::unit_value::UnitVal;
 
-    fn num(x: f32) -> Expr {
+    fn num(x: f32) -> Expr<UnitVal> {
         ENum(UnitVal::scalar(x))
     }
 
-    fn boxed_num(x: f32) -> Box<Expr> {
+    fn boxed_num(x: f32) -> Box<Expr<UnitVal>> {
         Box::new(num(x))
     }
 
     #[test]
     fn parse_add_statement() {
-        let parsed = parse("12 + 34".into()).unwrap();
+        let parsed = parse::<UnitVal>("12 + 34".into()).unwrap();
         let expected = EAdd(boxed_num(12.0), boxed_num(34.0));
         assert_eq!(parsed, expected);
     }
 
     #[test]
     fn parse_subtract_statement() {
-        let parsed = parse("12 - 34".into()).unwrap();
+        let parsed = parse::<UnitVal>("12 - 34".into()).unwrap();
         let expected = ESub(boxed_num(12.0), boxed_num(34.0));
         assert_eq!(parsed, expected);
     }
 
     #[test]
     fn parse_nested_add_sub_statements() {
-        let parsed = parse("12 - 34 + 15 - 9".into()).unwrap();
+        let parsed = parse::<UnitVal>("12 - 34 + 15 - 9".into()).unwrap();
         let expected = ESub(
             Box::new(EAdd(
                 Box::new(ESub(boxed_num(12.0), boxed_num(34.0))),
@@ -295,14 +294,14 @@ mod tests {
 
     #[test]
     fn test_parse_decimal() {
-        let parsed = parse("1.2".into()).unwrap();
+        let parsed = parse::<UnitVal>("1.2".into()).unwrap();
         let expected = ENum(UnitVal::scalar(1.2));
         assert_eq!(parsed, expected);
     }
 
     #[test]
     fn test_parse_multi_level_expression() {
-        let parsed = parse("1 * 2 + 3 / 4 ^ 6".into()).unwrap();
+        let parsed = parse::<UnitVal>("1 * 2 + 3 / 4 ^ 6".into()).unwrap();
         let expected = EAdd(
             Box::new(EMul(boxed_num(1.0), boxed_num(2.0))),
             Box::new(EDiv(
@@ -315,7 +314,7 @@ mod tests {
 
     #[test]
     fn test_parse_expression_with_parentheses() {
-        let parsed = parse("(1 + 2) * \\left(3\\right)".into()).unwrap();
+        let parsed = parse::<UnitVal>("(1 + 2) * \\left(3\\right)".into()).unwrap();
         let expected = EMul(
             Box::new(EAdd(boxed_num(1.0), boxed_num(2.0))),
             boxed_num(3.0),
@@ -325,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_variable_definition() {
-        let parsed = parse("a = 2".into()).unwrap();
+        let parsed = parse::<UnitVal>("a = 2".into()).unwrap();
         let expected = EDefVar(
             "a".to_string(),
             boxed_num(2.0),
@@ -335,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_function_definition() {
-        let parsed = parse("f(x, y) = x + y".into()).unwrap();
+        let parsed = parse::<UnitVal>("f(x, y) = x + y".into()).unwrap();
         let expected = EDefFunc(
             "f".to_string(),
             vec!["x".to_string(), "y".to_string()],
@@ -346,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_function_call() {
-        let parsed = parse("f(1,a)".into()).unwrap();
+        let parsed = parse::<UnitVal>("f(1,a)".into()).unwrap();
         let expected = EFunc(
             "f".to_string(),
             vec![num(1.0), EVar("a".to_string())],
@@ -356,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_latex() {
-        let parsed = parse("\\frac{1}{2}".into()).unwrap();
+        let parsed = parse::<UnitVal>("\\frac{1}{2}".into()).unwrap();
         let expected = ETex(
             LatexExpr {
                 name: "frac".to_string(),
@@ -367,7 +366,7 @@ mod tests {
         );
         assert_eq!(parsed, expected);
 
-        let parsed = parse("\\sum^{3}_{i=1}{i}".into()).unwrap();
+        let parsed = parse::<UnitVal>("\\sum^{3}_{i=1}{i}".into()).unwrap();
         let expected = ETex(
             LatexExpr {
                 name: "sum".to_string(),
@@ -377,19 +376,19 @@ mod tests {
             }
         );
         assert_eq!(parsed, expected);
-        let parsed = parse("\\sum_{i=1}^{3}{i}".into()).unwrap();
+        let parsed = parse::<UnitVal>("\\sum_{i=1}^{3}{i}".into()).unwrap();
         assert_eq!(parsed, expected);
     }
 
     #[test]
     fn test_units() {
-        let parsed = parse("1 km + 1 m".into()).unwrap();
+        let parsed = parse::<UnitVal>("1 km + 1 m".into()).unwrap();
         let expected = EAdd(
             Box::new(EMul(boxed_num(1.0), Box::new(ENum(UnitVal::new_identity("km"))))),
             Box::new(EMul(boxed_num(1.0), Box::new(ENum(UnitVal::new_identity("m"))))),
         );
         assert_eq!(parsed, expected);
-        let parsed = parse("100 m^2".into()).unwrap();
+        let parsed = parse::<UnitVal>("100 m^2".into()).unwrap();
         let expected = EMul(
             boxed_num(100.0),
             Box::new(EExp(Box::new(ENum(UnitVal::new_identity("m"))), boxed_num(2.0)))
@@ -399,7 +398,7 @@ mod tests {
 
     #[test]
     fn test_full() {
-        let parsed = parse("f(x, y) = x + \\sum^{3}_{i=1}{i*y}".into()).unwrap();
+        let parsed = parse::<UnitVal>("f(x, y) = x + \\sum^{3}_{i=1}{i*y}".into()).unwrap();
         let expected = EDefFunc(
             "f".to_string(),
             vec!["x".to_string(), "y".to_string()],

--- a/src-tauri/src/parser.rs
+++ b/src-tauri/src/parser.rs
@@ -200,7 +200,7 @@ fn parse_enum<T>(parsed_num: Span) -> Expr<T> where for<'a> T: BaseField<'a> + '
 }
 
 fn into_enum<T>(parsed_num: &str) -> Expr<T> where for<'a> T: BaseField<'a> + 'a {
-    let num = f32::from_str(parsed_num).unwrap();
+    let num = f64::from_str(parsed_num).unwrap();
     ENum(num.into())
 }
 
@@ -221,8 +221,8 @@ fn match_unit<T>(input: Span) -> Result<Expr<T>, Box<dyn std::error::Error>> whe
 
 fn match_const<T>(input: Span) -> Result<Expr<T>, Box<dyn std::error::Error>> where for<'a> T: BaseField<'a> + 'a {
     match *input.fragment() {
-        "e" => Ok(ENum(std::f32::consts::E.into())),
-        "pi" => Ok(ENum(std::f32::consts::PI.into())),
+        "e" => Ok(ENum(std::f64::consts::E.into())),
+        "pi" => Ok(ENum(std::f64::consts::PI.into())),
         _ => Err(Box::new(ParseError::new("Unknown constant", input))),
     }
 }
@@ -257,11 +257,11 @@ mod tests {
     use super::*;
     use crate::unit_value::UnitVal;
 
-    fn num(x: f32) -> Expr<UnitVal> {
+    fn num(x: f64) -> Expr<UnitVal> {
         ENum(UnitVal::scalar(x))
     }
 
-    fn boxed_num(x: f32) -> Box<Expr<UnitVal>> {
+    fn boxed_num(x: f64) -> Box<Expr<UnitVal>> {
         Box::new(num(x))
     }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -2,38 +2,55 @@ use std::collections::HashMap;
 use nom;
 use nom_locate::LocatedSpan;
 
-use crate::unit_value::UnitVal;
 use crate::error::{Error, ParseError};
 
 
 pub type CResult<T> = Result<T, Error>;
 
 
+pub trait BaseField<'a>: 
+    std::fmt::Debug + Clone +
+    std::convert::TryFrom<&'a str, Error=Box<dyn std::error::Error>> +
+    std::convert::From<f32> +
+    std::ops::Add<Output = CResult<Self>> +
+    std::ops::Sub<Output = CResult<Self>> +
+    std::ops::Mul<Output = Self> +
+    std::ops::Div<Output = Self>
+{
+    fn as_scalar(&self) -> CResult<f32>;
+    fn powf(&self, exp: Self) -> CResult<Self>;
+    fn root(&self, n: i32) -> CResult<Self>;
+    fn fract(&self) -> CResult<f32>;
+    fn sin(&self) -> CResult<Self>;
+    fn cos(&self) -> CResult<Self>;
+    fn tan(&self) -> CResult<Self>;
+}
+
 #[derive(Debug, PartialEq, Clone)]
-pub enum Expr {
-    ENum(UnitVal),
+pub enum Expr<T> where for<'a> T: BaseField<'a> {
+    ENum(T),
     EVar(String),
-    EFunc(String, Vec<Expr>),
-    EAdd(Box<Expr>, Box<Expr>),
-    ESub(Box<Expr>, Box<Expr>),
-    EMul(Box<Expr>, Box<Expr>),
-    EDiv(Box<Expr>, Box<Expr>),
-    EExp(Box<Expr>, Box<Expr>),
-    ETex(LatexExpr),
-    EDefVar(String, Box<Expr>),
-    EDefFunc(String, Vec<String>, Box<Expr>),
+    EFunc(String, Vec<Expr<T>>),
+    EAdd(Box<Expr<T>>, Box<Expr<T>>),
+    ESub(Box<Expr<T>>, Box<Expr<T>>),
+    EMul(Box<Expr<T>>, Box<Expr<T>>),
+    EDiv(Box<Expr<T>>, Box<Expr<T>>),
+    EExp(Box<Expr<T>>, Box<Expr<T>>),
+    ETex(LatexExpr<T>),
+    EDefVar(String, Box<Expr<T>>),
+    EDefFunc(String, Vec<String>, Box<Expr<T>>),
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct LatexExpr {
+pub struct LatexExpr<T> where for<'a> T: BaseField<'a> {
     pub name: String,
-    pub superscript: Option<Box<Expr>>,
-    pub subscript: Option<Box<Expr>>,
-    pub params: Vec<Expr>,
+    pub superscript: Option<Box<Expr<T>>>,
+    pub subscript: Option<Box<Expr<T>>>,
+    pub params: Vec<Expr<T>>,
 }
 
-impl LatexExpr {
-    pub fn set_script_param(&mut self, script: char, expr: Expr) -> Result<(), &str> {
+impl<T> LatexExpr<T> where for<'a> T: BaseField<'a> {
+    pub fn set_script_param(&mut self, script: char, expr: Expr<T>) -> Result<(), &str> {
         match script {
             '^' => self.superscript = {
                 if self.superscript.is_some() {
@@ -54,12 +71,12 @@ impl LatexExpr {
 }
 
 #[derive(Debug, Clone)]
-pub struct Context {
-    pub vars: HashMap<String, UnitVal>,
-    pub funcs: HashMap<String, (Vec<String>, Expr)>,
+pub struct Context<T> where for<'a> T: BaseField<'a> {
+    pub vars: HashMap<String, T>,
+    pub funcs: HashMap<String, (Vec<String>, Expr<T>)>,
 }
 
-impl Context {
+impl<T> Context<T> where for<'a> T: BaseField<'a> {
     pub fn new() -> Self {
         Context {
             vars: HashMap::new(),
@@ -71,6 +88,6 @@ impl Context {
 
 pub type Span<'a> = LocatedSpan<&'a str>;
 pub type BaseParseResult<'a, T> = nom::IResult<Span<'a>, T, ParseError>;
-pub type ParseResult<'a> = BaseParseResult<'a, Expr>;
+pub type ParseResult<'a, T> = BaseParseResult<'a, Expr<T>>;
 pub type ParseResultStr<'a> = BaseParseResult<'a, Span<'a>>;
-pub type ParseResultVec<'a> = BaseParseResult<'a, Vec<Expr>>;
+pub type ParseResultVec<'a, T> = BaseParseResult<'a, Vec<Expr<T>>>;

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -10,6 +10,8 @@ pub type CResult<T> = Result<T, Error>;
 
 pub trait BaseField<'a>: 
     std::fmt::Debug + Clone +
+    std::fmt::Display +
+    serde::Serialize +
     std::convert::TryFrom<&'a str, Error=Box<dyn std::error::Error>> +
     std::convert::From<f64> +
     std::ops::Add<Output = CResult<Self>> +
@@ -19,7 +21,7 @@ pub trait BaseField<'a>:
 {
     fn as_scalar(&self) -> CResult<f64>;
     fn powf(&self, exp: Self) -> CResult<Self>;
-    fn root(&self, n: i32) -> CResult<Self>;
+    fn root(&self, n: Self) -> CResult<Self>;
     fn fract(&self) -> CResult<f64>;
     fn sin(&self) -> CResult<Self>;
     fn cos(&self) -> CResult<Self>;

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -11,16 +11,16 @@ pub type CResult<T> = Result<T, Error>;
 pub trait BaseField<'a>: 
     std::fmt::Debug + Clone +
     std::convert::TryFrom<&'a str, Error=Box<dyn std::error::Error>> +
-    std::convert::From<f32> +
+    std::convert::From<f64> +
     std::ops::Add<Output = CResult<Self>> +
     std::ops::Sub<Output = CResult<Self>> +
     std::ops::Mul<Output = Self> +
     std::ops::Div<Output = Self>
 {
-    fn as_scalar(&self) -> CResult<f32>;
+    fn as_scalar(&self) -> CResult<f64>;
     fn powf(&self, exp: Self) -> CResult<Self>;
     fn root(&self, n: i32) -> CResult<Self>;
-    fn fract(&self) -> CResult<f32>;
+    fn fract(&self) -> CResult<f64>;
     fn sin(&self) -> CResult<Self>;
     fn cos(&self) -> CResult<Self>;
     fn tan(&self) -> CResult<Self>;

--- a/src-tauri/src/unit_value.rs
+++ b/src-tauri/src/unit_value.rs
@@ -131,17 +131,20 @@ impl<'a> BaseField<'a> for UnitVal {
             let exp = exp as i32;
             Ok(self.powi(exp))
         } else if exp.abs() < 1.0 && (1.0 / exp).fract() == 0.0 {
-            let n  = (1.0 / exp) as i32;
-            self.root(n)
+            let n  = 1.0 / exp;
+            self.root(UnitVal::scalar(n))
         } else {
             let value = self.as_scalar()?.powf(exp);
             Ok(UnitVal::scalar(value))
         }
     }
 
-    fn root(&self, n: i32) -> CResult<Self> {
-        if let Ok(new_quantity) = self.quantity.clone().root(n) {
-            let exp = 1.0 / (n as f64);
+    fn root(&self, n: Self) -> CResult<Self> {
+        let n = n.as_scalar()?;
+        if n.fract() != 0.0 {
+            Err(Error::UnitError(format!("Cannot take the {n}th root of {self}")))
+        } else if let Ok(new_quantity) = self.quantity.clone().root(n as i32) {
+            let exp = 1.0 / n;
             Ok(UnitVal::new(self.value.powf(exp), new_quantity))
         } else {
             Err(Error::UnitError(format!("Cannot take the {n}th root of {self}")))

--- a/src-tauri/src/unit_value.rs
+++ b/src-tauri/src/unit_value.rs
@@ -7,22 +7,22 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnitVal {
-    pub value: f32,
+    pub value: f64,
     pub quantity: Quantity,
 }
 
 
 impl UnitVal {
-    pub fn new(value: f32, quantity: Quantity) -> Self {
+    pub fn new(value: f64, quantity: Quantity) -> Self {
         UnitVal { value, quantity }
     }
 
-    pub fn new_value(value: f32, unit: &str) -> Self {
+    pub fn new_value(value: f64, unit: &str) -> Self {
         if unit.is_empty() {
             return UnitVal::scalar(value);
         }
         let (exp, base_unit) = UnitVal::from_unit_str(unit).unwrap();
-        let scale_factor = 10.0_f32.powf(exp as f32);
+        let scale_factor = 10.0_f64.powf(exp as f64);
         let value = value * scale_factor;
         UnitVal::new(base_unit.to_si(value), base_unit.quantity.clone())
     }
@@ -53,7 +53,7 @@ impl UnitVal {
             let val_exp = val.log10().floor() as i32;
             // Reduce the exponent to the nearest multiple of 3
             let val_exp = val_exp / 3 * 3;
-            let reduced_val = val / 10.0_f32.powf(val_exp as f32);
+            let reduced_val = val / 10.0_f64.powf(val_exp as f64);
             // Account for the exponent of the unit it's being applied to
             let val_exp = val_exp / *numerator_unit_exp;
             if let Some(prefix) = prefix_map().get_by_right(&val_exp) {
@@ -106,7 +106,7 @@ impl UnitVal {
         UnitVal::new(self.value.powi(n), self.quantity.powi(n))
     }
 
-    pub fn scalar(value: f32) -> UnitVal { UnitVal::new(value, Quantity::unitless()) }
+    pub fn scalar(value: f64) -> UnitVal { UnitVal::new(value, Quantity::unitless()) }
 }
 
 
@@ -117,7 +117,7 @@ impl std::fmt::Display for UnitVal {
 }
 
 impl<'a> BaseField<'a> for UnitVal {
-    fn as_scalar(&self) -> Result<f32, Error> {
+    fn as_scalar(&self) -> Result<f64, Error> {
         if self.quantity != Quantity::unitless() {
             Err(Error::UnitError(format!("Cannot convert unit to scalar: {}", self)))
         } else {
@@ -126,7 +126,7 @@ impl<'a> BaseField<'a> for UnitVal {
     }
 
     fn powf(&self, exp: UnitVal) -> CResult<Self> {
-        let exp: f32 = exp.as_scalar()?;
+        let exp: f64 = exp.as_scalar()?;
         if exp.fract() == 0.0 {
             let exp = exp as i32;
             Ok(self.powi(exp))
@@ -141,14 +141,14 @@ impl<'a> BaseField<'a> for UnitVal {
 
     fn root(&self, n: i32) -> CResult<Self> {
         if let Ok(new_quantity) = self.quantity.clone().root(n) {
-            let exp = 1.0 / (n as f32);
+            let exp = 1.0 / (n as f64);
             Ok(UnitVal::new(self.value.powf(exp), new_quantity))
         } else {
             Err(Error::UnitError(format!("Cannot take the {n}th root of {self}")))
         }
     }
 
-    fn fract(&self) -> Result<f32, Error> {
+    fn fract(&self) -> Result<f64, Error> {
         println!("Var: {:?}", self.as_scalar());
         let value = self.as_scalar()? % 1.0;
         Ok(value)
@@ -222,8 +222,8 @@ impl<'a> std::convert::TryFrom<&'a str> for UnitVal {
     }
 }
 
-impl std::convert::From<f32> for UnitVal {
-    fn from(value: f32) -> Self {
+impl std::convert::From<f64> for UnitVal {
+    fn from(value: f64) -> Self {
         UnitVal::scalar(value)
     }
 }

--- a/src-tauri/src/units.rs
+++ b/src-tauri/src/units.rs
@@ -9,13 +9,13 @@ use std::{collections::HashMap, sync::OnceLock, vec};
 #[derive(Debug, Clone, PartialEq)]
 pub struct Unit {
     pub name: String,
-    pub si_scale: f32,
+    pub si_scale: f64,
     pub quantity: Quantity,
     // TODO: Add optional max and min prefixes (e.g. can't have megametres)
 }
 
 impl Unit {
-    pub fn new(name: &str, si_scale: f32, quantity: Quantity) -> Self {
+    pub fn new(name: &str, si_scale: f64, quantity: Quantity) -> Self {
         Unit { name: name.to_string(), si_scale, quantity }
     }
 
@@ -85,11 +85,11 @@ impl Unit {
         }
     }
 
-    pub fn to_si(&self, value: f32) -> f32 {
+    pub fn to_si(&self, value: f64) -> f64 {
         value * self.si_scale
     }
 
-    pub fn from_si(&self, value: f32) -> f32 {
+    pub fn from_si(&self, value: f64) -> f64 {
         value / self.si_scale
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,38 @@
 <script lang="ts">
 	import Calculator from "./Calculator.svelte";
 	// import Graph from './Graph.svelte';
+
+	let use_units = false;
+	let use_complex = false;
+	let mode: 'float' | 'complex' | 'units' = 'float';
+
+	$: use_units, updateMode('units', use_units);
+	$: use_complex, updateMode('complex', use_complex);
+
+	// TODO: Automatically detect mode
+	function updateMode(new_mode: 'units' | 'complex' | 'float', state: boolean) {
+		if (mode != new_mode && state) {
+			mode = new_mode;
+			if (new_mode == 'units') {
+				use_complex = false;
+			} else if (new_mode == 'complex') {
+				use_units = false;
+			}
+		} else if (mode == new_mode && !state) {
+			mode = 'float';
+			use_units = false;
+			use_complex = false;
+		}
+	}
 </script>
 
 <section>
   	<h1>Dansmos</h1>
-	<Calculator />
+	<Calculator mode={mode} />
+	<ul>
+		<p><input type="checkbox" bind:checked={use_units} /> Units</p>
+		<p><input type="checkbox" bind:checked={use_complex} /> Complex Numbers</p>
+	</ul>
 	<br />
 	<!-- <Graph equation="{latex}" /> -->
 </section>
@@ -21,5 +48,6 @@
 
 	h1 {
 		width: 100%;
+		font-family: 'Courier New', Courier, monospace;
 	}
 </style>

--- a/src/routes/Calculator.svelte
+++ b/src/routes/Calculator.svelte
@@ -4,6 +4,9 @@
     import { toast } from '@zerodevx/svelte-toast';
     import CalculatorRow from './CalculatorRow.svelte';
 
+
+    export let mode: 'float' | 'complex' | 'units' = 'float';
+
 	listen('open-file', (event: { event: String, payload: String }) => {
         latexes = event.payload?.split('\n') || [''];
         toast.push("Opened file!");
@@ -16,7 +19,7 @@
 	let latexes = [''];
 	let results: any = [];
 
-	$: latexes, invoke('evaluate', { input: latexes.join('\n') }).then((res: any) => {
+	$: latexes, invoke(`evaluate_${mode}`, { input: latexes.join('\n') }).then((res: any) => {
 		results = res;
 	}).catch((err) => {
 		console.error(err);

--- a/src/routes/CalculatorRow.svelte
+++ b/src/routes/CalculatorRow.svelte
@@ -24,7 +24,7 @@
         if (!res) {
             parsed_result = {Ok: '', Err: ''};
         } else if ('Ok' in res) {
-            parsed_result = {Ok: res.Ok, Err: ''};
+            parsed_result = {Ok: String(res.Ok).replaceAll(/\^([0-9]+)/g, "<sup>$1</sup>"), Err: ''};
         } else if ('Err' in res) {
             parsed_result = {Ok: '', Err: parseError(res.Err)};
         } else {
@@ -70,7 +70,7 @@
             autofocus
         />
         {#if parsed_result.Ok}
-            <i>{@html parsed_result.Ok.replaceAll(/\^([0-9]+)/g, "<sup>$1</sup>")}</i>
+            <i>{@html parsed_result.Ok}</i>
         {:else if parsed_result.Err}
             <!-- svelte-ignore a11y-no-static-element-interactions -->
             <div class="error-container" on:mouseenter={() => show_error = true} on:mouseleave={() => show_error = false}>


### PR DESCRIPTION
Allows the underlying type that the calculator uses to be swapped out. Currently allows
- Float64
- Complex64
- UnitVal64